### PR TITLE
chore(ghooks): Add ghooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "2.5.1",
     "eslint-config-airbnb": "6.2.0",
     "eslint-plugin-react": "4.2.3",
+    "ghooks": "1.0.3",
     "mocha": "2.4.5",
     "semantic-release": "^4.3.5"
   },
@@ -41,5 +42,10 @@
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"
+  },
+  "config": {
+    "ghooks": {
+      "pre-commit": "npm run test"
+    }
   }
 }


### PR DESCRIPTION
Protect ourselves from commiting code that breaks the tests by running the
tests before you can commit. ghooks automatically sets this up on your
system when you do an `npm install`.

closes #5