### PR TITLE
Istanbul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ before_script:
   - npm prune
 script:
   - npm run test
-after_success:
-  - npm run semantic-release
   - npm run check-coverage
+after_success:
+  - npm run report-coverage
+  - npm run semantic-release
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - npm run test
 after_success:
   - npm run semantic-release
+  - npm run check-coverage
 branches:
   except:
     - "/^v\\d+\\.\\d+\\.\\d+$/"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # jo12bar-starwars-names
 [![Build Status](https://img.shields.io/travis/jo12bar/jo12bar-starwars-names.svg?style=flat-square)](https://travis-ci.org/jo12bar/jo12bar-starwars-names)
+[![Codecov](https://img.shields.io/codecov/c/github/jo12bar/jo12bar-starwars-names.svg?style=flat-square)](https://codecov.io/github/jo12bar/jo12bar-starwars-names)
 [![npm](https://img.shields.io/npm/v/jo12bar-starwars-names.svg?style=flat-square)](http://npm.im/jo12bar-starwars-names)
 [![Downloads per month](https://img.shields.io/npm/dm/jo12bar-starwars-names.svg?style=flat-square)](http://npm.im/jo12bar-starwars-names)
 [![GitHub license](https://img.shields.io/github/license/jo12bar/jo12bar-starwars-names.svg?style=flat-square)](https://github.com/jo12bar/jo12bar-starwars-names/blob/master/LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "commit": "git-cz",
-    "test": "mocha",
+    "test": "istanbul cover -x test/**/* node_modules/mocha/bin/_mocha -- -R spec test",
     "test:watch": "mocha -w",
     "lint": "node_modules/.bin/eslint -c .eslintrc.js src",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -34,6 +34,7 @@
     "eslint-config-airbnb": "6.2.0",
     "eslint-plugin-react": "4.2.3",
     "ghooks": "1.0.3",
+    "istanbul": "0.4.2",
     "mocha": "2.4.5",
     "semantic-release": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "commit": "git-cz",
+    "report-coverage": "cat coverage/lcov.info | codecov",
     "test": "istanbul cover -x test/**/* node_modules/mocha/bin/_mocha -- -R spec test",
     "test:watch": "mocha -w",
     "lint": "node_modules/.bin/eslint -c .eslintrc.js src",
@@ -29,6 +30,7 @@
   "homepage": "https://github.com/jo12bar/jo12bar-starwars-names#readme",
   "devDependencies": {
     "chai": "3.5.0",
+    "codecov.io": "0.1.6",
     "commitizen": "2.7.3",
     "cz-conventional-changelog": "1.1.5",
     "eslint": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Gives random Star Wars name. Not actually intended for use.",
   "main": "src/index.js",
   "scripts": {
+    "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "commit": "git-cz",
     "test": "istanbul cover -x test/**/* node_modules/mocha/bin/_mocha -- -R spec test",
     "test:watch": "mocha -w",
@@ -46,7 +47,7 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "npm run test"
+      "pre-commit": "npm run test && npm run check-coverage"
     }
   }
 }


### PR DESCRIPTION
Add [istanbul](http://npm.im/istanbul) for code coverage. Closes #7.

Changes made:
- [x] Use istanbul + mocha for `npm run test` command. Tests using mocha, and generates code coverage reports.
- [x] Add `check-coverage` npm script
  * Use istanbul to make sure that coverage is at 100%
  * Add as `pre-commit` git hook, so that only code with 100% coverage can be committed
  * Run in Travis CI to make *extra sure* that coverage is at 100%. Anything less should fail the build.
    * Useful for if you need to bypass the `check-coverage` script if you're having trouble writing the tests. You can do a `git commit --no-verify`, push it to GitHub, and open a pull request. There, you can ask for help writing the tests, and Travis CI will let the repo owner know that the tests aren't yet finished so that he doesn't merge it.
- [x] Add code coverage reporting using [codecov.io](https://codeov.io)
- [x] Add coverage badge to `README.md` (I :heart: badges)